### PR TITLE
Fixed not compiling when using 27xx profile

### DIFF
--- a/TommyPROM/PromDevice27.cpp
+++ b/TommyPROM/PromDevice27.cpp
@@ -85,6 +85,7 @@ bool PromDevice27::burnByte(byte value, uint32_t address)
     bool status = false;
     unsigned writeCount = 0;
 
+    byte data = 0;
     disableOutput();
     disableWrite();
     enableChip();


### PR DESCRIPTION
I'm not sure if this is the correct fix but without this one line the code wouldn't compile and it would say that "data" wasn't declared.