### PR TITLE
update PgmType for 27C040 EPROM

### DIFF
--- a/TommyPROM/TommyPROM.ino
+++ b/TommyPROM/TommyPROM.ino
@@ -48,7 +48,7 @@ PromDevice28C  prom(32 * 1024L, 64, 10, true);
 //PromDevice27  prom(8 * 1024L, E27C_PGM_WE, 1000L, 15, 4);  // 2764 with SEEQ intelligent programming
 //PromDevice27  prom(32 * 1024L, E27C_PGM_WE, 1000L, 25, 3); // 27C256 with SEEQ intelligent programming
 //PromDevice27  prom(2 * 1024L, E27C_PGM_WE, 50000L, 1, 0);  // 2716 with single 50ms write
-//PromDevice27  prom(512 * 1024L, E27C_PGM_WE, 100L, 11, 0); // 27C040 with Atmel rapid programming
+//PromDevice27  prom(512 * 1024L, E27C_PGM_CE, 100L, 11, 0); // 27C040 with Atmel rapid programming, CE connected to CE#/PGM#
 //PromDevice27  prom(32 * 1024L, E27C_PGM_CE, 100L, 25, 0);  // W27C257/W27E257 with 100uS program pulse on CE
 //PromDevice27  prom(64 * 1024L, E27C_PGM_CE, 100L, 1, 0, false);  // W27C512 with single 100uS program pulse on CE, no verify
 PromDevice27  prom(256 * 1024L, E27C_PGM_WE, 20L, 1, 0, false); // SST27SF020 with single 20us write, no verify


### PR DESCRIPTION
The (AMD/Atmel) 27C040 EPROM doesn't have a dedicated Write Enable (WE), instead sharing the same pin for CE# and PGM#. This updates the PromDevice27 line for this device to use the E27C_PGM_CE PgmType.

This configuration has been successfully used to read, program and verify an AM27C040 device. A +12.75V voltage was applied to Vpp during the duration of device programming.