### PR TITLE
add 23xx support

### DIFF
--- a/TommyPROM/Configure.h
+++ b/TommyPROM/Configure.h
@@ -11,6 +11,7 @@
 //#define PROM_IS_SST39SF
 //#define PROM_IS_SST28SF
 //#define PROM_IS_8755A
+//#define PROM_IS_23
 
 // Don't change anything below this comment unless you are adding support for a new device type.
 #if defined(PROM_IS_28C)
@@ -23,6 +24,9 @@
 #include "PromDeviceSST28SF.h"
 #elif defined(PROM_IS_8755A)
 #include "PromDevice8755A.h"
+#elif defined(PROM_IS_23)
+#include "PromDevice23.h"
+
 // Additional device support goes here...
 // Also add matching code in TommyPROM.ino to declare the new device
 #else

--- a/TommyPROM/PromDevice23.cpp
+++ b/TommyPROM/PromDevice23.cpp
@@ -1,0 +1,79 @@
+// NOTE - The 23 series device support is a work in progress.  It
+//        has not been tested or documented.
+
+#include "Configure.h"
+#if defined(PROM_IS_23)
+
+#include "PromAddressDriver.h"
+
+// IO lines for the EPROM device control
+// Pins D2..D9 are used for the data bus.
+#define CS3              A0
+#define CS1              A1
+#define CS2              A2
+
+// Set the status of the device control pins
+static void enableCS1()     { digitalWrite(CS1, HIGH); }
+static void disableCS1()    { digitalWrite(CS1, LOW);}
+static void enableCS2()     { digitalWrite(CS2, HIGH); }
+static void disableCS2()    { digitalWrite(CS2, LOW);}
+static void enableCS3()     { digitalWrite(CS3, HIGH); }
+static void disableCS3()    { digitalWrite(CS3, LOW);}
+
+
+PromDevice23::PromDevice23(uint32_t size)
+    : PromDevice(size, 0, 0, false)
+{
+}
+
+
+void PromDevice23::begin()
+{
+    // Define the data bus as input initially so that it does not put out a
+    // signal that could collide with output on the data pins of the EEPROM.
+    setDataBusMode(INPUT);
+
+    pinMode(CS1, OUTPUT);
+    pinMode(CS2, OUTPUT);
+    pinMode(CS3, OUTPUT);
+    
+    disableCS1();
+    disableCS2();
+    disableCS3();
+
+    // This chip uses the shift register hardware for addresses, so initialize that.
+    PromAddressDriver::begin();
+}
+
+
+// BEGIN PRIVATE METHODS
+//
+
+// Use the PromAddressDriver to set a 16 bit address in the two address shift registers.
+void PromDevice23::setAddress(uint32_t address)
+{
+    PromAddressDriver::setAddress(address);
+}
+
+
+// Read a byte from a given address
+byte PromDevice23::readByte(uint32_t address)
+{
+    byte data = 0;
+    setAddress(address);
+    setDataBusMode(INPUT);
+    enableCS1();
+    enableCS2();
+    enableCS3();
+
+    delayMicroseconds(20);
+    data = readDataBus();
+
+    disableCS3();
+    disableCS2();
+    disableCS1();
+
+    return data;
+}
+
+#endif // #if defined(PROM_IS_23)

--- a/TommyPROM/PromDevice23.h
+++ b/TommyPROM/PromDevice23.h
@@ -1,0 +1,34 @@
+// NOTE - The 23 series device support is a work in progress.  It
+//        has not been tested or documented.
+
+
+#ifndef INCLUDE_PROM_DEVICE_23_H
+#define INCLUDE_PROM_DEVICE_23_H
+
+#include "Arduino.h"
+#include "PromDevice.h"
+
+/*****************************************************************************/
+/*****************************************************************************/
+/**
+ * PromDevice23 class
+ *
+ * Provides the device-specific interface to read data from a
+ * 23 series parallel PROM using the Arduino.  Supported chips
+ * include 2316.
+ */
+
+class PromDevice23 : public PromDevice
+{
+  public:
+    PromDevice23(uint32_t size);
+    void begin();
+    const char *getName() { return "23 series PROM"; }
+
+  protected:
+    void setAddress(uint32_t address);
+    byte readByte(uint32_t address);
+    bool burnByte(byte value, uint32_t address) { return false; }
+};
+
+#endif  // #define INCLUDE_PROM_DEVICE_23_H

--- a/TommyPROM/TommyPROM.ino
+++ b/TommyPROM/TommyPROM.ino
@@ -36,6 +36,7 @@ CmdStatus cmdStatus;
 //   Data polling supported
 PromDevice28C  prom(32 * 1024L, 64, 10, true);
 //PromDevice28C  prom(8 * 1024L, 0, 10, true);  // 28C64 with no page writes
+//PromDevice28C  prom(2 * 1024L, 0, 10, true);  // 28C16 with no page writes
 
 #elif defined(PROM_IS_27)
 // Define a device for a 2764 EPROM with the following parameters:
@@ -71,6 +72,9 @@ PromDeviceSST28SF  prom(512 * 1024L, 40, true);
 #elif defined(PROM_IS_8755A)
 // Define a device for an Intel 8755A with a fixed size of 2K and no other parameters.
 PromDevice8755A  prom(2 * 1024L);
+
+#elif defined(PROM_IS_23)
+PromDevice23 prom(2 * 1024L);	// 2316
 
 // Additional device-specific code goes here...
 //#elif defined(PROM_IS...


### PR DESCRIPTION
Add support for reading 23xx-series ROMs as found in microcomputers from 70s and 80s.

Also add line for 28C16.